### PR TITLE
 Raise min versions of MW and PHP; clean-up CI testing config 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: php
 
 matrix:
   include:
-    - env: DB=mysql; MW=REL1_28; TYPE=coverage
-      php: 7.0
-    - env: DB=sqlite; MW=1.26.4
-      php: 5.3
-      dist: precise
-      sudo: required
     - env: DB=mysql; MW=master;
+      php: 7.2
+    - env: DB=mysql; MW=REL1_30; TYPE=coverage
+      php: 7.0
+    - env: DB=mysql; MW=REL1_28
       php: 5.6
+    - env: DB=mysql; MW=REL1_27
+      php: 5.5
   allow_failures:
     - env: DB=mysql; MW=master;
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,10 @@ This file contains the RELEASE-NOTES of the Semantic Glossary (a.k.a. SG) extens
 
 Released on 2018-????.
 
+* New minimum required versions:
+  * PHP 5.5
+  * MediaWiki 1.27
+
 * Compatibility with Semantic MediaWiki 3.0
 * Compatibility with MediaWiki 1.31
 * Compatibility with Lingo 3.0

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 		"irc": "irc://irc.freenode.org/semantic-mediawiki"
 	},
 	"require": {
-		"php": ">=5.3.3",
+		"php": ">=5.5",
 		"composer/installers":"^1.0.12",
 		"mediawiki/semantic-media-wiki": "^2.4|^3.0",
 		"mediawiki/lingo": "^2.0.3|^3.0"

--- a/extension.json
+++ b/extension.json
@@ -11,7 +11,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {
-		"MediaWiki": "~1.26"
+		"MediaWiki": "~1.27"
 	},
 	"MessagesDirs": {
 		"SemanticGlossary": [

--- a/tests/phpunit/Unit/Cache/CacheInvalidatorTest.php
+++ b/tests/phpunit/Unit/Cache/CacheInvalidatorTest.php
@@ -46,6 +46,9 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
+		$store->method( 'getPropertyValues' )
+			->willReturn( [] );
+
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
@@ -76,6 +79,9 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase {
 		$store = $this->getMockBuilder( 'SMWStore' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
+
+		$store->method( 'getPropertyValues' )
+			->willReturn( [] );
 
 		$semanticData = new SemanticData( $subject );
 		$semanticData->addPropertyObjectValue(

--- a/tests/phpunit/Unit/SemanticDataComparatorTest.php
+++ b/tests/phpunit/Unit/SemanticDataComparatorTest.php
@@ -45,6 +45,9 @@ class SemanticDataComparatorTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
+		$store->method( 'getPropertyValues' )
+			->willReturn( [] );
+
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();


### PR DESCRIPTION
This PR is made in reference to: #36 

This PR addresses or contains:
* New minimum required versions:
  * PHP 5.5
  * MediaWiki 1.27
* Fix some tests to avoid warnings from PHP 7.2

This PR includes:
- [x] Update of RELEASE-NOTES.md
- [x] Tests (unit/integration)
- [x] CI build passed
