### PR TITLE
Bump min versions of dependencies; switch to new major version number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - env: DB=mysql; MW=REL1_28
       php: 5.6
     - env: DB=mysql; MW=REL1_27
-      php: 5.5
+      php: 5.6
   allow_failures:
     - env: DB=mysql; MW=master;
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ terms and abbreviations can be defined using semantic properties.
 
 ## Requirements
 
-- PHP 5.3.3 or later
-- MediaWiki 1.26 or later
+- PHP 5.6 or later
+- MediaWiki 1.27 or later
 - [Semantic MediaWiki][smw] 2.4 or later
 
 ## Installation
@@ -24,7 +24,7 @@ Just add the following to the MediaWiki `composer.local.json` file and run the
 ```json
 {
 	"require": {
-		"mediawiki/semantic-glossary": "~2.1"
+		"mediawiki/semantic-glossary": "~3.0"
 	}
 }
 ```

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,11 +1,11 @@
 This file contains the RELEASE-NOTES of the Semantic Glossary (a.k.a. SG) extension.
 
-### 2.3.0
+### 3.0.0
 
 Released on 2018-????.
 
 * New minimum required versions:
-  * PHP 5.5
+  * PHP 5.6
   * MediaWiki 1.27
 
 * Compatibility with Semantic MediaWiki 3.0

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.x-dev"
+			"dev-master": "3.x-dev"
 		}
 	},
 	"autoload": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Semantic Glossary",
-	"version": "2.3.0-alpha",
+	"version": "3.0.0-alpha",
 	"author": [
 		"[https://www.mediawiki.org/wiki/User:F.trott Stephan Gambke]",
 		"[https://www.semantic-mediawiki.org/wiki/User:MWJames James Hong Kong]",


### PR DESCRIPTION
This PR addresses or contains:
- Bump min versions of dependencies to keep compat w/ SMW 3.0
This PR includes:
- [x] Update of RELEASE-NOTES.md
- [x] Tests (unit/integration)
- [x] CI build passed
