### PR TITLE
Load Extension:Lingo only if not already loaded (#43)

### DIFF
--- a/SemanticGlossary.php
+++ b/SemanticGlossary.php
@@ -19,12 +19,15 @@ class SemanticGlossary {
 			require_once __DIR__ . '/vendor/autoload.php';
 		}
 
-		// must NOT use ExtensionRegistry::getInstance() to avoid recursion!
-		$registry = new ExtensionRegistry();
-		if ( file_exists( __DIR__ . '/extensions/Lingo/extension.json' ) ) {
-			$registry->load( __DIR__ . '/extensions/Lingo/extension.json' );
-		} else {
-			$registry->load( $GLOBALS[ 'wgExtensionDirectory' ] . '/Lingo/extension.json' );
+		// Load Extension:Lingo - but only if not already loaded
+		if ( ! class_exists( 'Lingo\Lingo' ) ) {
+			// must NOT use ExtensionRegistry::getInstance() to avoid recursion!
+			$registry = new ExtensionRegistry();
+			if ( file_exists( __DIR__ . '/extensions/Lingo/extension.json' ) ) {
+				$registry->load( __DIR__ . '/extensions/Lingo/extension.json' );
+			} else {
+				$registry->load( $GLOBALS[ 'wgExtensionDirectory' ] . '/Lingo/extension.json' );
+			}
 		}
 
 		$GLOBALS[ 'wgexLingoBackend' ] = 'SG\LingoBackendAdapter';


### PR DESCRIPTION
This PR is made in reference to: #43 

This PR addresses the problems that arise if for some reason Extension:Lingo is already installed and loaded outside SemanticGlossary.