### PR TITLE
CacheInvalidator to check null

### DIFF
--- a/src/Cache/CacheInvalidator.php
+++ b/src/Cache/CacheInvalidator.php
@@ -78,7 +78,11 @@ class CacheInvalidator {
 	 *
 	 * @return boolean
 	 */
-	public function invalidateCacheOnStoreUpdate( Store $store, SemanticData $semanticData ) {
+	public function invalidateCacheOnStoreUpdate( Store $store, SemanticData $semanticData = null ) {
+
+		if ( $semanticData === null ) {
+			return false;
+		}
 
 		$this->matchAllSubobjects( $store, $semanticData );
 

--- a/tests/phpunit/Unit/Cache/CacheInvalidatorTest.php
+++ b/tests/phpunit/Unit/Cache/CacheInvalidatorTest.php
@@ -59,6 +59,20 @@ class CacheInvalidatorTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( $instance->invalidateCacheOnStoreUpdate( $store, $semanticData ) );
 	}
 
+	public function testInvalidateOnUpdateWithNullSemanticData() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new CacheInvalidator();
+		$instance->setCache( new GlossaryCache( new HashBagOStuff() ) );
+
+		$this->assertFalse(
+			$instance->invalidateCacheOnStoreUpdate( $store, null )
+		);
+	}
+
 	public function testInvalidateOnUpdateWithDifferentSubobjectData() {
 
 		$subject = DIWikiPage::newFromTitle( Title::newFromText( __METHOD__ ) );


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/3702#issuecomment-462156091

This PR addresses or contains:

- `$semanticData->findSubSemanticData( $subobject->getSubobjectName() )` can return NULL (as seen in ref) therefore allow NULL and skip the invalidation on those occasions

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
