### PR TITLE
Fix use of `Maintenance::addDefaultParams`, refs 49

### DIFF
--- a/maintenance/rebuildGlossaryCache.php
+++ b/maintenance/rebuildGlossaryCache.php
@@ -39,6 +39,7 @@ class RebuildGlossaryCache extends \Maintenance {
 	 * @see Maintenance::addDefaultParams
 	 */
 	protected function addDefaultParams() {
+		parent::addDefaultParams();
 		$this->addOption( 'verbose', 'Be verbose about the progress', false, false, 'v' );
 		$this->addOption( 'quiet', 'Do not give any output', false );
 	}


### PR DESCRIPTION
This PR is made in reference to: #49

This PR addresses or contains:


This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes: #49
