### PR TITLE
The PageMoveComplete hook is replacing TitleMoveComplete in 1.35

### DIFF
--- a/src/Cache/CacheInvalidator.php
+++ b/src/Cache/CacheInvalidator.php
@@ -12,7 +12,7 @@ use SMW\DIProperty;
 
 use Lingo\LingoParser;
 
-use Title;
+use MediaWiki\Linker\LinkTarget;
 
 /**
  * @ingroup SG
@@ -118,12 +118,12 @@ class CacheInvalidator {
 	/**
 	 * @since 1.0
 	 *
-	 * @param Title $title
+	 * @param LinkTarget $title
 	 *
 	 * @return boolean
 	 */
-	public function invalidateCacheOnPageMove( Title $title ) {
-		$this->purgeCache( DIWikiPage::newFromTitle( $title ) );
+	public function invalidateCacheOnPageMove( LinkTarget $title ) {
+		$this->purgeCache( DIWikiPage::newFromText( $title->getDBkey(), $title->getNamespace() );
 		return true;
 	}
 

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -2,8 +2,9 @@
 
 namespace SG;
 
-use SMW\DIWikiPage;
 use Hooks;
+use MediaWiki\Linker\LinkTarget;
+use SMW\DIWikiPage;
 
 /**
  * @license GNU GPL v2+
@@ -94,10 +95,15 @@ class HookRegistry {
 		 *
 		 * @since 1.0
 		 */
-		$this->handlers['TitleMoveComplete'] = function ( &$old_title ) {
-			return \SG\Cache\CacheInvalidator::getInstance()->invalidateCacheOnPageMove( $old_title );
-		};
-
+		if ( version_compare( MW_VERSION, "1.35.0", "<" ) ) {
+			$this->handlers['TitleMoveComplete'] = function ( &$old_title ) {
+				return \SG\Cache\CacheInvalidator::getInstance()->invalidateCacheOnPageMove( $old_title );
+			};
+		} else {
+			$this->handlers['PageMoveComplete'] = function ( LinkTarget $old_title ) {
+				return \SG\Cache\CacheInvalidator::getInstance()->invalidateCacheOnPageMove( $old_title );
+			};
+		}
 	}
 
 }


### PR DESCRIPTION
* Also, LinkTarget is preferred to Title.