### PR TITLE
Pin Lingo version to 3.1.1 since Lingo 3.2.0 requires MW 1.39+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 		"php": ">=7.1",
 		"composer/installers":"^1.0.12",
 		"mediawiki/semantic-media-wiki": "^3.1|^3.2|^4.0",
-		"mediawiki/lingo": "^3.1.1"
+		"mediawiki/lingo": "3.1.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^8.5"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 		"php": ">=7.1",
 		"composer/installers":"^1.0.12",
 		"mediawiki/semantic-media-wiki": "^3.1|^3.2|^4.0",
-		"mediawiki/lingo": "^3.1"
+		"mediawiki/lingo": "^3.1.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^8.5"


### PR DESCRIPTION
fixes #69 