### PR TITLE
Updates Lingo dependency to 3.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 		"php": ">=7.1",
 		"composer/installers":"^1.0.12",
 		"mediawiki/semantic-media-wiki": "^3.1|^3.2|^4.0",
-		"mediawiki/lingo": "3.1.1"
+		"mediawiki/lingo": "3.1.2"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^8.5"


### PR DESCRIPTION
Lingo 3.1.2 is equal to REL1_39 of the Lingo. The tag was previously missing from Lingo and was recently added. It was also noticed that Lingo 3.1.1 and SemanticGlossary latest `master` version does not work on 1.39.5, but Lingo 3.1.2 does work